### PR TITLE
NativePRNGNonBlockingを使う

### DIFF
--- a/src/main/java/jp/sawa_kai/sawakai/spigot/skyway/SkyWayClient.kt
+++ b/src/main/java/jp/sawa_kai/sawakai/spigot/skyway/SkyWayClient.kt
@@ -89,7 +89,7 @@ class SkyWayClient(
     fun connect() {
         Bukkit.getLogger().info("Signaling server is $signalingServerUrl")
 
-        val token = SecureRandom.getInstanceStrong()
+        val token = SecureRandom.getInstance("NativePRNGNonBlocking")
             .nextLong()
             .toString(36)
             .substring(2)


### PR DESCRIPTION
SecureRandomはLinuxではデフォルトで`/dev/random`を使うが、`/dev/random`がブロックすると一生Minecraft serverが起動しなくなるので直した。